### PR TITLE
Bump com.rabbitmq:amqp-client to version 5.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>
-            <version>5.2.0</version>
+            <version>5.4.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Moderate severity security issue.

Pivotal Spring AMQP, 1.x versions prior to 1.7.10 and 2.x versions prior to 2.0.6, expose a man-in-the-middle vulnerability due to lack of hostname validation. A malicious user that has the ability to intercept traffic would be able to view data in transit.